### PR TITLE
Add new item to network category about community

### DIFF
--- a/senior-engineer-checklist.json
+++ b/senior-engineer-checklist.json
@@ -419,6 +419,13 @@
       "effort": "medium",
       "caimpact": "medium",
       "coimpact": "high"
+    },
+    {
+      "task": "Be part of a community by contributing with discussions, content creation, and career advices. This will help you to build authority and relevance in the field",
+      "category": "network",
+      "effort": "medium",
+      "caimpact": "high",
+      "coimpact": "low"
     }
   ]
 }


### PR DESCRIPTION
Hi everyone!
I want to contribute with the Senior's Checklist (which has been helping me strongly in the last months) with this item. I'm a community builder, and one aspect that has been helping in my career is a closer relationship with the community. Contribute to the community helped me to reach people that I didn't have the chance to reach in the past, at the same time it helped me to create an authority among the community members (e.g. people look at me as a reference for their career, asking for advice, etc.). I do believe that this is something that senior engineers should pursue in their careers. It's a win-win situation: it will help enthusiastic and junior professionals with better guidance for their careers, and it will make you a reference and relevant member of the community.